### PR TITLE
Add an action to generate a signed timestamp

### DIFF
--- a/.github/workflows/generate-timestamp.yaml
+++ b/.github/workflows/generate-timestamp.yaml
@@ -1,4 +1,4 @@
-name: Generate a timestamp
+name: Generate a signed timestamp
 
 on:
   workflow_dispatch:
@@ -21,7 +21,7 @@ jobs:
         with:
           arguments: installDist
 
-      - name: Generate a timestamp
+      - name: Generate a signed timestamp
         run: |
           echo "${{ secrets.PRIVATE_KEY_PEM }}" > $HOME/private-key.pem
           lib/build/install/lib/bin/generate-signed-timestamp --private-key-file=$HOME/private-key.pem > $HOME/timestamp.json

--- a/.github/workflows/generate-timestamp.yaml
+++ b/.github/workflows/generate-timestamp.yaml
@@ -1,0 +1,42 @@
+name: Generate a timestamp
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 */6 * * *'
+
+jobs:
+  generate-timestamp:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout scalar-licensing repo
+        uses: actions/checkout@v3
+        with:
+          repository: scalar-labs/scalar-licensing
+          token: ${{ secrets.TIMESTAMP_GH_PAT }}
+
+      - name: Setup and execute Gradle 'installDist' task
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: installDist
+
+      - name: Generate a timestamp
+        run: |
+          echo "${{ secrets.PRIVATE_KEY_PEM }}" > $HOME/private-key.pem
+          lib/build/install/lib/bin/generate-signed-timestamp --private-key-file=$HOME/private-key.pem > $HOME/timestamp.json
+
+      - name: Checkout this repo
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.TIMESTAMP_GH_PAT }}
+
+      - name: Commit the timestamp
+        run: |
+          cp $HOME/timestamp.json .
+          git config user.name github-actions
+          git config user.email action@github.com
+          git add .
+          git commit -m "Update the timestamp"
+          git push
+

--- a/.github/workflows/generate-timestamp.yaml
+++ b/.github/workflows/generate-timestamp.yaml
@@ -37,6 +37,6 @@ jobs:
           git config user.name github-actions
           git config user.email action@github.com
           git add .
-          git commit -m "Update the timestamp"
-          git push
+          git commit --amend -m "Update the timestamp"
+          git push -f
 


### PR DESCRIPTION
This PR adds a GitHub action to generate a signed timestamp on a regular basis.
Currently, it's configured to generate it every 6 hours.